### PR TITLE
maintain the column width of user's choice

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 
 cd ..
 
-version='2.1'
+version='2.11'
 
 rm -f zoterocitationcountsmanager-${version}.xpi
 zip -r zoterocitationcountsmanager-${version}.xpi locale/* icons/* manifest.json bootstrap.js preferences.js preferences.xhtml prefs.js zoterocitationcounts.js

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -22,6 +22,7 @@ async function startup({ id, version, rootURI }) {
     ),
     pluginID: id,
     dataProvider: (item) => ZoteroCitationCounts.getCitationCount(item),
+    zoteroPersist: ['width', 'hidden', 'sortDirection'], // persist the column properties
   });
 
   itemObserver = Zotero.Notifier.registerObserver(


### PR DESCRIPTION
Thank you for your debugging of some issues of this plugin so that I can use it well.
I see there is a issue for maintaining the column width of the user's choice FrLars21/ZoteroCitationCountsManager#9.
I followed the instructions and add `zoteroPersist: ['width', 'hidden', 'sortDirection'], // persist the column properties` in bootstrap.js. I have tested several times and the plugin works well so I think I can create the pull request.
Thanks for your help.